### PR TITLE
Add pre-fetching to Batch image page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ init-yarn:
 init: ## Build local development environment
 	make init-poetry
 	make init-yarn
+	# Folder needs to exist, it can be empty.
+	mkdir -p ./qsl/frontend/static
 
 develop: ## Start local development on frontend and backend
 	FRONTEND_PORT=$(FRONTEND_PORT) $(PYTHON_EXEC) qsl label --dev --port $(BACKEND_PORT) & cd frontend && PORT=$(FRONTEND_PORT) REACT_APP_API_URL=http://localhost:$(BACKEND_PORT) yarn start

--- a/frontend/src/components/BatchImageLabel.tsx
+++ b/frontend/src/components/BatchImageLabel.tsx
@@ -125,7 +125,7 @@ export const BatchImageLabel = () => {
     batchSize: 10,
     thumbnailSize: 160,
     redirecting: false,
-    advanceOnSave: false,
+    advanceOnSave: true,
     history: [] as HistoryEntry[],
     project: null as sharedTypes.Project,
     currentBatchStatus: {} as BatchStatuses,

--- a/frontend/src/components/BatchImageLabel.tsx
+++ b/frontend/src/components/BatchImageLabel.tsx
@@ -389,6 +389,7 @@ export const BatchImageLabel = () => {
     0
   );
   return (
+    <div>
     <mui.Grid container spacing={2}>
       <mui.Grid item xs={12}>
         <LabelingStatus project={navState.project}>
@@ -655,5 +656,18 @@ export const BatchImageLabel = () => {
         </mui.Grid>
       </mui.Grid>
     </mui.Grid>
+
+  {navState.batches && navState.batches.length
+    ? navState.batches.map((images, batch_index) => (
+     images.map((image, index) => (
+          <img
+            key={index}
+            alt={`Background Load: ${image.id}`}
+            src={common.getImageUrl(projectId, image.id)}
+            style={{ width: 0, height: 0 }}
+          />
+      ))))
+    : null}
+</div>
   );
 };

--- a/frontend/src/components/BatchImageLabel.tsx
+++ b/frontend/src/components/BatchImageLabel.tsx
@@ -665,7 +665,7 @@ export const BatchImageLabel = () => {
     ? navState.batches.map((images, batch_index) => (
      images.map((image, index) => (
           <img
-            key={index}
+            key={image.id}
             alt={`Background Load: ${image.id}`}
             src={common.getImageUrl(projectId, image.id)}
             style={{ width: 0, height: 0 }}

--- a/frontend/src/components/ImageAdder.tsx
+++ b/frontend/src/components/ImageAdder.tsx
@@ -43,6 +43,17 @@ export const ImageAdder = () => {
         </rrd.Link>
         <mui.Typography variant="h5">Add Files to Project</mui.Typography>
       </mui.Grid>
+      <mui.Grid item xs={12}>
+        <mui.Button
+          onClick={addFiles}
+          disabled={files.length === 0}
+          style={{ width: "100%" }}
+          variant="contained"
+          color="primary"
+        >
+          Add Files
+        </mui.Button>
+      </mui.Grid>
       <mui.Grid item xs={6}>
         <ChipInput
           label="New Files"
@@ -76,17 +87,6 @@ export const ImageAdder = () => {
             setDraftDefaultLabels({ ...draftDefaultLabels, image: labels })
           }
         />
-      </mui.Grid>
-      <mui.Grid item xs={12}>
-        <mui.Button
-          onClick={addFiles}
-          disabled={files.length === 0}
-          style={{ width: "100%" }}
-          variant="contained"
-          color="primary"
-        >
-          Add Files
-        </mui.Button>
       </mui.Grid>
     </mui.Grid>
   );

--- a/frontend/src/components/SingleImageLabel.tsx
+++ b/frontend/src/components/SingleImageLabel.tsx
@@ -931,7 +931,7 @@ export const SingleImageLabel = () => {
               <img
                 key={index}
                 alt={`Background Load: ${image.id}`}
-                src={common.getImageUrl(projectId, imageId)}
+                src={common.getImageUrl(projectId, image.id)}
                 style={{ width: 0, height: 0 }}
               />
             ))

--- a/frontend/src/components/SingleImageLabel.tsx
+++ b/frontend/src/components/SingleImageLabel.tsx
@@ -930,7 +930,7 @@ export const SingleImageLabel = () => {
         {navState.queue && navState.queue.length
           ? navState.queue.map((image, index) => (
               <img
-                key={index}
+                key={image.id}
                 alt={`Background Load: ${image.id}`}
                 src={common.getImageUrl(projectId, image.id)}
                 style={{ width: 0, height: 0 }}

--- a/frontend/src/components/SingleImageLabel.tsx
+++ b/frontend/src/components/SingleImageLabel.tsx
@@ -361,7 +361,7 @@ export const SingleImageLabel = () => {
       | "redirecting",
     usePolygon: false,
     labels: null as sharedTypes.ImageLabels,
-    advanceOnSave: false,
+    advanceOnSave: true,
     dirty: false,
     notice: null as string,
     history: [] as HistoryEntry[],


### PR DESCRIPTION
Other small changes:
- Move 'Add Files' button to above text box to save scrolling 100s of lines after pasting links
- Fix typo/bug on pre-fetching for single images
- Make missing dir on init
- Set default for advanceOnSave to true


Note, I was unsure of the purpose of `key=` in the prefetching code on batches, I'm not sure if I set it to a reasonable value.

issue: https://github.com/faustomorales/qsl/issues/1