### PR TITLE
Fix issue when kind is None

### DIFF
--- a/qsl/files.py
+++ b/qsl/files.py
@@ -250,5 +250,6 @@ def guess_type(target: typing.Union[str, "np.ndarray"]):
         return "image" if ext in IMAGE_EXTENSIONS else "video"
     if isinstance(target, str) and os.path.isfile(target):
         kind = filetype.guess(target)
-        return "image" if kind.mime.startswith("image") else "video"
+        if kind:
+            return "image" if kind.mime.startswith("image") else "video"
     return "image"


### PR DESCRIPTION
`filetype.guess` can return `None`, which throws an error when we call `startswith` on it.