### PR TITLE
Make globbing recursive

### DIFF
--- a/qsl/files.py
+++ b/qsl/files.py
@@ -109,7 +109,7 @@ def filepaths_from_patterns(patterns: typing.List[str], s3=None) -> typing.List[
             # We have no way of handling wildcards for HTTP URLs.
             filepaths.append(file_or_pattern)
         else:
-            filepaths.extend(glob.glob(file_or_pattern))
+            filepaths.extend(glob.glob(file_or_pattern, recursive=True))
     return filepaths
 
 


### PR DESCRIPTION
This change updates globbing to be recursive. Not being recursive makes it difficult to find arbitrary files under a directory, which can be a barrier to labeling large amounts of data.